### PR TITLE
fix: replace deprecated mx logger

### DIFF
--- a/src/CheckBoxFilter/components/CheckBoxFilterContainer.ts
+++ b/src/CheckBoxFilter/components/CheckBoxFilterContainer.ts
@@ -127,7 +127,7 @@ export default class CheckboxFilterContainer extends Component<ContainerProps, C
 
     private applyFilter(isChecked: boolean, restoreState = false) {
         if (this.dataSourceHelper) {
-            mx.logger.debug(this.props.uniqueid, "applyFilter", isChecked, this.props.group);
+            console.debug(this.props.uniqueid, "applyFilter", isChecked, this.props.group);
             this.dataSourceHelper.setConstraint(this.props.uniqueid, this.getConstraint(isChecked), this.props.group, restoreState);
             this.setState({ isChecked });
         }

--- a/src/DropDownFilter/components/DropDownFilterContainer.ts
+++ b/src/DropDownFilter/components/DropDownFilterContainer.ts
@@ -148,7 +148,7 @@ export default class DropDownFilterContainer extends Component<ContainerProps, C
     private applyFilter(selectedFilter: FilterProps, restoreState = false) {
         const constraint = this.getConstraint(selectedFilter);
         if (this.dataSourceHelper) {
-            mx.logger.debug(this.props, this.props.uniqueid, "applyFilter", constraint);
+            console.debug(this.props, this.props.uniqueid, "applyFilter", constraint);
             this.dataSourceHelper.setConstraint(this.props.uniqueid, constraint, undefined, restoreState);
         }
         this.setState({ selectedOption: selectedFilter });

--- a/src/DropDownSort/components/DropDownSortContainer.ts
+++ b/src/DropDownSort/components/DropDownSortContainer.ts
@@ -162,7 +162,7 @@ export default class DropDownSortContainer extends Component<ContainerProps, Con
         const { targetListView } = this.state;
 
         if (targetListView && this.dataSourceHelper) {
-            mx.logger.debug(this.props.uniqueid, "updateSort", selectedOption.name, selectedOption.sort);
+            console.debug(this.props.uniqueid, "updateSort", selectedOption.name, selectedOption.sort);
             this.dataSourceHelper.setSorting(this.props.uniqueid, [ selectedOption.name, selectedOption.sort ], restoreState);
             this.setState({ selectedOption });
             this.publishWidgetChanges(selectedOption);

--- a/src/Pagination/components/PaginationContainer.ts
+++ b/src/Pagination/components/PaginationContainer.ts
@@ -52,7 +52,7 @@ class PaginationContainer extends Component<ModelerProps, PaginationContainerSta
     constructor(props: ModelerProps) {
         super(props);
 
-        mx.logger.debug(this.props.uniqueid, ".constructor");
+        console.debug(this.props.uniqueid, ".constructor");
 
         this.updateListView = this.updateListView.bind(this);
         this.translateMessageStatus = this.translateMessageStatus.bind(this);
@@ -76,13 +76,13 @@ class PaginationContainer extends Component<ModelerProps, PaginationContainerSta
     }
 
     async componentDidMount() {
-        mx.logger.debug(this.props.uniqueid, ".componentDidMount");
+        console.debug(this.props.uniqueid, ".componentDidMount");
         const isValidConfig = !!mx.session.getConfig("uiconfig.translations");
         if (!isValidConfig) {
             try {
                 await getTranslations();
             } catch (e) {
-                mx.logger.debug(this.props.uniqueid, ".loadingTranslations", e.message);
+                console.debug(this.props.uniqueid, ".loadingTranslations", e.message);
             }
             this.setState({ loadTranslations: true });
         }
@@ -90,7 +90,7 @@ class PaginationContainer extends Component<ModelerProps, PaginationContainerSta
     }
 
     render() {
-        mx.logger.debug(this.props.uniqueid, ".render");
+        console.debug(this.props.uniqueid, ".render");
         return createElement("div",
             {
                 className: classNames("widget-pagination", this.props.class),
@@ -105,7 +105,7 @@ class PaginationContainer extends Component<ModelerProps, PaginationContainerSta
     }
 
     componentWillUnmount() {
-        mx.logger.debug(this.props.uniqueid, ".componentWillUnmount");
+        console.debug(this.props.uniqueid, ".componentWillUnmount");
         showLoadMoreButton(this.state.targetListView);
         this.viewStateManager.destroy();
     }
@@ -115,7 +115,7 @@ class PaginationContainer extends Component<ModelerProps, PaginationContainerSta
     }
 
     private checkListViewAvailable(): boolean {
-        mx.logger.debug(this.props.uniqueid, ".checkListViewAvailable");
+        console.debug(this.props.uniqueid, ".checkListViewAvailable");
         if (!this.widgetDom) {
             return false;
         }
@@ -129,11 +129,11 @@ class PaginationContainer extends Component<ModelerProps, PaginationContainerSta
     }
 
     private renderPageButton(): ReactNode {
-        mx.logger.debug(this.props.uniqueid, ".renderPageButton");
+        console.debug(this.props.uniqueid, ".renderPageButton");
 
         if (this.state.validationPassed && this.state.pageSize && this.state.targetListView!._datasource.getSetSize() > 0) {
             const { offset, pageSize } = this.state;
-            mx.logger.debug(this.props.uniqueid, ".renderPageButton pagesize, offset, listsize", pageSize, offset, this.state.targetListView!._datasource.getSetSize());
+            console.debug(this.props.uniqueid, ".renderPageButton pagesize, offset, listsize", pageSize, offset, this.state.targetListView!._datasource.getSetSize());
 
             return createElement(Pagination, {
                 getMessageStatus: this.translateMessageStatus,
@@ -152,7 +152,7 @@ class PaginationContainer extends Component<ModelerProps, PaginationContainerSta
     }
 
     public updateListView(offSet?: number, pageSize?: number) {
-        mx.logger.debug(this.props.uniqueid, ".updateListView");
+        console.debug(this.props.uniqueid, ".updateListView");
         if (this.state.validationPassed) {
             this.setState({
                 offset: offSet !== undefined ? offSet : this.state.offset,
@@ -194,10 +194,10 @@ class PaginationContainer extends Component<ModelerProps, PaginationContainerSta
     }
 
     private beforeListViewDataRender(targetListView: DataSourceHelperListView) {
-        mx.logger.debug(this.props.uniqueid, ".beforeListViewDataRender");
+        console.debug(this.props.uniqueid, ".beforeListViewDataRender");
 
         dojoAspect.before(targetListView, "_renderData", () => {
-            mx.logger.debug(this.props.uniqueid, "_renderData.before");
+            console.debug(this.props.uniqueid, "_renderData.before");
 
             const datasource = targetListView._datasource;
             if (datasource.getSetSize() === 0) {
@@ -229,7 +229,7 @@ class PaginationContainer extends Component<ModelerProps, PaginationContainerSta
                         listSize: datasource.getSetSize()
                     });
                 } else {
-                    mx.logger.debug(this.props.uniqueid, ".initialLoading False, pagingLoading False");
+                    console.debug(this.props.uniqueid, ".initialLoading False, pagingLoading False");
                     const previousOffset = this.state.offset;
                     const listSize = datasource.getSetSize();
                     let offset = previousOffset;
@@ -258,7 +258,7 @@ class PaginationContainer extends Component<ModelerProps, PaginationContainerSta
     }
 
     private afterListViewLoaded(targetListView: DataSourceHelperListView) {
-        mx.logger.debug(this.props.uniqueid, ".afterListViewLoad");
+        console.debug(this.props.uniqueid, ".afterListViewLoad");
         // Initial load of list view, also take in account the previous page state
         const datasource = targetListView._datasource;
         const pageSize = this.state.pageSize ? this.state.pageSize : datasource.getPageSize() && datasource.getPageSize() || 10;
@@ -271,9 +271,9 @@ class PaginationContainer extends Component<ModelerProps, PaginationContainerSta
     }
 
     private afterListViewDataRender(targetListView: DataSourceHelperListView) {
-        mx.logger.debug(this.props.uniqueid, ".afterListViewDataRender");
+        console.debug(this.props.uniqueid, ".afterListViewDataRender");
         dojoAspect.after(targetListView, "_renderData", () => {
-            mx.logger.debug(this.props.uniqueid, "_renderData.after");
+            console.debug(this.props.uniqueid, "_renderData.after");
             resetListViewHeight(targetListView.domNode as HTMLElement);
         });
     }

--- a/src/Pagination/utils/ContainerUtils.ts
+++ b/src/Pagination/utils/ContainerUtils.ts
@@ -44,7 +44,7 @@ export const getListNode = (targetNode: HTMLElement): HTMLUListElement => {
 };
 
 export const setListNodeToEmpty = (targetNode: HTMLElement) => {
-    mx.logger.debug("setListNodeToEmpty");
+    console.debug("setListNodeToEmpty");
     // Explicitly remove children as IE does not like listNode.innerHTML = "";
     const listNode = targetNode.querySelector("ul") as HTMLUListElement;
     while (listNode.firstChild) {
@@ -53,12 +53,12 @@ export const setListNodeToEmpty = (targetNode: HTMLElement) => {
 };
 
 export const showLoader = (targetListView: DataSourceHelperListView) => {
-    mx.logger.debug("showLoader");
+    console.debug("showLoader");
     targetListView.domNode.classList.add("widget-pagination-loading");
 };
 
 export const hideLoader = (targetListView: DataSourceHelperListView) => {
-    mx.logger.debug("hideLoader");
+    console.debug("hideLoader");
     targetListView.domNode.classList.remove("widget-pagination-loading");
 };
 
@@ -84,6 +84,6 @@ export const getTranslations = async (): Promise<void> => {
         const localeIndex = metadataJson.languages.indexOf(localeCode);
         window.__widgets_translations = Object.keys(systemTexts).reduce((translations, currentKey) => ({ ...translations, [currentKey]: systemTexts[currentKey][localeIndex] }), {});
     } else {
-        mx.logger.error("Error while loading translations");
+        console.error("Error while loading translations");
     }
 };

--- a/src/Shared/DataSourceHelper/DataSourceHelper.ts
+++ b/src/Shared/DataSourceHelper/DataSourceHelper.ts
@@ -48,7 +48,7 @@ export class DataSourceHelper {
         this.originalSort = window.mx.isOffline() ? this.widget._datasource._sort : this.widget._datasource._sorting;
 
         aspect.after(widget, "storeState", (store: (key: string, value: any) => void) => {
-            mx.logger.debug("after storeState");
+            console.debug("after storeState");
             if (widget.__customWidgetDataSourceHelper) {
                 const sorting = widget.__customWidgetDataSourceHelper.sorting.length > 0 ? widget.__customWidgetDataSourceHelper.sorting : widget.__customWidgetDataSourceHelper.originalSort;
                 store("lvcSorting", sorting);
@@ -99,13 +99,13 @@ export class DataSourceHelper {
     }
 
     private registerUpdate(restoreState: boolean) {
-        mx.logger.debug("DataSourceHelper .registerUpdate");
+        console.debug("DataSourceHelper .registerUpdate");
         if (this.timeoutHandle) {
             window.clearTimeout(this.timeoutHandle);
         }
         if (!this.updateInProgress) {
             this.timeoutHandle = window.setTimeout(() => {
-                mx.logger.debug("DataSourceHelper .execute");
+                console.debug("DataSourceHelper .execute");
                 this.updateInProgress = true;
                 // TODO Check if there's currently no update happening on the listView coming from another
                 // Feature/functionality/widget which does not use DataSourceHelper
@@ -216,12 +216,12 @@ export class DataSourceHelper {
             } else {
                 this.widget._datasource._sorting = sorting;
             }
-            mx.logger.debug("DataSourceHelper .set sort and constraint");
+            console.debug("DataSourceHelper .set sort and constraint");
             const offset = this.widget._datasource.getOffset();
             const pageSize = this.widget._datasource.getPageSize();
             if (!this.widget.__lvcPagingEnabled && offset > 0) {
                 // In case load more is used, the data source have to reload the full content
-                mx.logger.debug("reset offset");
+                console.debug("reset offset");
                 this.widget._datasource.setOffset(0);
                 this.widget._datasource.setPageSize(pageSize + offset);
             }
@@ -230,9 +230,9 @@ export class DataSourceHelper {
             }
 
             this.widget.update(null, () => {
-                mx.logger.debug("DataSourceHelper .updated");
+                console.debug("DataSourceHelper .updated");
                 if (!this.widget.__lvcPagingEnabled && offset > 0) {
-                    mx.logger.debug("restore offset");
+                    console.debug("restore offset");
                     // Restore the original paging and offset for load more.
                     this.widget._datasource.setOffset(offset);
                     this.widget._datasource.setPageSize(pageSize);
@@ -292,13 +292,13 @@ export class DataSourceHelper {
         };
 
         if (changed) {
-            mx.logger.debug(".updateDatasource changed", offset, pageSize);
+            console.debug(".updateDatasource changed", offset, pageSize);
             this.widget.__customWidgetPagingLoading = true;
             this.showLoader();
             this.widget.sequence([ "_sourceReload", "_renderData" ], () => {
                 this.widget.__customWidgetPagingLoading = false;
                 resetListViewHeight(this.widget.domNode);
-                mx.logger.debug(".updateDatasource updated");
+                console.debug(".updateDatasource updated");
                 this.hideLoader();
             });
         }

--- a/src/Shared/FormViewState.ts
+++ b/src/Shared/FormViewState.ts
@@ -14,7 +14,7 @@ export class FormViewState<T> {
         const mxform = this.form;
         const widgetViewState = mxform && mxform.viewState ? mxform.viewState[this.widgetId] : void 0;
         const state = widgetViewState && widgetViewState[key] !== undefined ? widgetViewState[key] : defaultValue;
-        mx.logger.debug("getPageState", this.widgetId, key, defaultValue, state);
+        console.debug("getPageState", this.widgetId, key, defaultValue, state);
         return state;
     }
 

--- a/src/Shared/ListViewPrototype.ts
+++ b/src/Shared/ListViewPrototype.ts
@@ -14,7 +14,7 @@ import { v4 as uuid } from "uuid";
         ListView.prototype.__lvcPrototypeUpdated = true;
         ListView.prototype.__postCreateOriginal = ListView.prototype.postCreate;
         ListView.prototype.postCreate = function(this: DataSourceHelperListView) {
-            mx.logger.debug("list view control, overwrites postCreate prototype");
+            console.debug("list view control, overwrites postCreate prototype");
             this.__postCreateOriginal();
             if (!listviewInstanceCompatible(this)) return;
 
@@ -41,7 +41,7 @@ import { v4 as uuid } from "uuid";
 
         ListView.prototype.__loadDataOriginal = ListView.prototype._loadData;
         ListView.prototype._loadData = function(this: DataSourceHelperListView, callback: () => void) {
-            mx.logger.debug("List view control, overwrites _loadData prototype");
+            console.debug("List view control, overwrites _loadData prototype");
             if (!listviewInstanceCompatible(this)) {
                 this.__loadDataOriginal(callback);
                 return;
@@ -78,7 +78,7 @@ import { v4 as uuid } from "uuid";
             });
         };
     } else {
-        mx.logger.debug("Prototype update called unexpected again");
+        console.debug("Prototype update called unexpected again");
     }
 
     function listviewPrototypeCompatible(listview: DataSourceHelperListView) {
@@ -90,7 +90,7 @@ import { v4 as uuid } from "uuid";
             && listview._renderData
         );
         if (!compatible) {
-            mx.logger.error("This Mendix version is not compatible with list view controls. The List view prototype could not be updated.");
+            console.error("This Mendix version is not compatible with list view controls. The List view prototype could not be updated.");
         }
         return compatible;
     }
@@ -113,7 +113,7 @@ import { v4 as uuid } from "uuid";
             && listview._datasource.getOffset
         );
         if (!compatible) {
-            mx.logger.error("This Mendix version is not compatible with list view controls. The List view controls use is limited.");
+            console.error("This Mendix version is not compatible with list view controls. The List view controls use is limited.");
         }
         return compatible;
     }

--- a/tslint.json
+++ b/tslint.json
@@ -22,7 +22,7 @@
       "no-bitwise": true,
       "no-conditional-assignment": true,
       "no-console": [
-        true
+        false
       ],
       "no-debugger": true,
       "no-duplicate-variable": true,


### PR DESCRIPTION
With Mendix x, mx. The logger was deprecated; it still works however, it pollutes the console.
- Replace `mx.logger.` by the browser `window.console.`